### PR TITLE
enforcePeriodicBox in hremd

### DIFF
--- a/femto/md/hremd.py
+++ b/femto/md/hremd.py
@@ -510,6 +510,7 @@ def run_hremd(
             replica_idx_offset,
             force_groups,
             config.max_step_retries,
+            enforcePB=enforcePB
         )
 
         if mpi_comm.rank == 0:
@@ -539,6 +540,7 @@ def run_hremd(
                 replica_idx_offset,
                 force_groups,
                 config.max_step_retries,
+                enforcePB=enforcePB
             )
             reduced_potentials = mpi_comm.reduce(reduced_potentials, MPI.SUM, 0)
 

--- a/femto/md/simulate.py
+++ b/femto/md/simulate.py
@@ -80,6 +80,7 @@ def simulate_state(
     stages: list[femto.md.config.SimulationStage],
     platform: femto.md.constants.OpenMMPlatform,
     reporter: femto.md.reporting.openmm.OpenMMStateReporter | None = None,
+    enforcePB: bool = True
 ) -> openmm.State:
     """Simulate a system following the specified ``stages``, at a given 'state' (i.e.
     a set of context parameters, such as free energy lambda values)
@@ -92,6 +93,7 @@ def simulate_state(
         platform: The accelerator to use.
         reporter: The reporter to use to record system statistics such as volume and
             energy.
+        enforcePB: Maintain wrapped coordinates in output.
 
     Returns:
         The final coordinates and box vectors.
@@ -143,8 +145,10 @@ def simulate_state(
             f"after {stage_name} "
             f"{femto.md.utils.openmm.get_simulation_summary(simulation)}"
         )
+        # enforcePeriodicBox
         coords = simulation.context.getState(
-            getPositions=True, getVelocities=True, getForces=True, getEnergy=True
+            getPositions=True, getVelocities=True, getForces=True, getEnergy=True,
+            enforcePeriodicBox=enforcePB
         )
 
     return coords

--- a/femto/md/simulate.py
+++ b/femto/md/simulate.py
@@ -145,7 +145,6 @@ def simulate_state(
             f"after {stage_name} "
             f"{femto.md.utils.openmm.get_simulation_summary(simulation)}"
         )
-        # enforcePeriodicBox
         coords = simulation.context.getState(
             getPositions=True, getVelocities=True, getForces=True, getEnergy=True,
             enforcePeriodicBox=enforcePB


### PR DESCRIPTION
Per [issue #1](https://github.com/Psivant/femto/issues/1), added `enforcePB` argument to simulate_state, _propagate_replicas, and run_hremd to maintain wrapped  coordinates in trajectory outputs.



## Status
- [ x] Ready to go
