### PR TITLE
Fix receptor ref atom automatic selection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Run Tests
       run: |
-        apt update && apt install -y git make
+        apt update && apt install -y git make rsh-client
 
         make env
         make lint

--- a/femto/fe/reference.py
+++ b/femto/fe/reference.py
@@ -441,12 +441,12 @@ def _filter_receptor_atoms(
             rmsf[rigid_backbone_idxs] < _RMSF_CUTOFF
         ]
 
-    distances = (
-        scipy.spatial.distance.cdist(
-            backbone.xyz[0, rigid_backbone_idxs, :], ligand.xyz[0, [ligand_ref_idx], :]
-        )
-        * openmm.unit.nanometer
+    distances = scipy.spatial.distance.cdist(
+        backbone.xyz[0, rigid_backbone_idxs, :], ligand.xyz[0, [ligand_ref_idx], :]
     )
+
+    minimum_distance = minimum_distance.value_in_unit(openmm.unit.nanometer)
+    maximum_distance = maximum_distance.value_in_unit(openmm.unit.nanometer)
 
     distance_mask = (distances > minimum_distance).all(axis=1)
     distance_mask &= (distances <= maximum_distance).any(axis=1)

--- a/femto/fe/reference.py
+++ b/femto/fe/reference.py
@@ -631,9 +631,7 @@ def select_receptor_idxs(
     Returns:
         The indices of the three atoms to use for the restraint
     """
-    if not isinstance(receptor, type(ligand)) and not isinstance(
-        ligand, type(receptor)
-    ):
+    if not (isinstance(receptor, type(ligand)) or isinstance(ligand, type(receptor))):
         raise ValueError("receptor and ligand must be the same type")
 
     if isinstance(receptor, parmed.Structure) and isinstance(ligand, parmed.Structure):
@@ -724,7 +722,7 @@ def check_receptor_idxs(
     Returns:
         True if the atoms meet the criteria, False otherwise.
     """
-    if type(receptor) != type(ligand):
+    if not (isinstance(receptor, type(ligand)) or isinstance(ligand, type(receptor))):
         raise ValueError("receptor and ligand must be the same type")
 
     if isinstance(receptor, parmed.Structure) and isinstance(ligand, parmed.Structure):

--- a/femto/fe/tests/septop/test_setup.py
+++ b/femto/fe/tests/septop/test_setup.py
@@ -100,9 +100,9 @@ def test_apply_complex_restraints(mocker):
         receptor + ligand_1,
         (0, 0, 0),
         (1, 1, 1),
-        None,
         config,
         system,
+        femto.fe.septop._setup.LAMBDA_BORESCH_LIGAND_1,
     )
 
     assert system.getNumForces() == 1
@@ -321,13 +321,25 @@ def test_setup_complex(cdk2_ligand_1, cdk2_ligand_2, cdk2_receptor, mocker):
     mock_setup_system.assert_called_once_with(
         mock_config, cdk2_ligand_1, cdk2_ligand_2, cdk2_receptor, None, None
     )
-    mock_apply_restraints.assert_called_once_with(
-        mocker.ANY,
-        (n_ligand_atoms, n_ligand_atoms + 1, n_ligand_atoms + 2),
-        (0, 1, 2),
-        (3, 4, 5),
-        mock_config.restraints,
-        mocker.ANY,
+    mock_apply_restraints.assert_has_calls(
+        [
+            mocker.call(
+                mocker.ANY,
+                (n_ligand_atoms, n_ligand_atoms + 1, n_ligand_atoms + 2),
+                (0, 1, 2),
+                mock_config.restraints,
+                mocker.ANY,
+                femto.fe.septop._setup.LAMBDA_BORESCH_LIGAND_1,
+            ),
+            mocker.call(
+                mocker.ANY,
+                (n_ligand_atoms, n_ligand_atoms + 1, n_ligand_atoms + 2),
+                (3, 4, 5),
+                mock_config.restraints,
+                mocker.ANY,
+                femto.fe.septop._setup.LAMBDA_BORESCH_LIGAND_2,
+            ),
+        ]
     )
 
 

--- a/femto/fe/tests/test_reference.py
+++ b/femto/fe/tests/test_reference.py
@@ -525,10 +525,6 @@ def test_is_valid_r3(
 
 
 def test_select_receptor_idxs(cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs):
-    from femto.fe.reference import select_ligand_idxs
-
-    x, _ = select_ligand_idxs(cdk2_ligand_1, None, "baumann")
-
     # computed using the reference SepTop implementation at commit 3705ba5
     expected_receptor_idxs = 830, 841, 399
 
@@ -536,6 +532,10 @@ def test_select_receptor_idxs(cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_id
         cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs
     )
     assert receptor_idxs == expected_receptor_idxs
+
+    assert femto.fe.reference.check_receptor_idxs(
+        cdk2_receptor, receptor_idxs, cdk2_ligand_1, cdk2_ligand_1_ref_idxs
+    )
 
 
 def test_select_protein_cavity_atoms(cdk2_receptor, cdk2_ligand_1, cdk2_ligand_2):

--- a/femto/fe/tests/test_reference.py
+++ b/femto/fe/tests/test_reference.py
@@ -1,5 +1,6 @@
 import copy
 
+import mdtraj
 import numpy
 import openmm.unit
 import parmed
@@ -8,6 +9,7 @@ import pytest
 import femto.fe.reference
 from femto.fe.reference import (
     _create_ligand_queries,
+    _structure_to_mdtraj,
     queries_to_idxs,
     select_ligand_idxs,
     select_protein_cavity_atoms,
@@ -22,10 +24,20 @@ def cdk2_receptor() -> parmed.Structure:
 
 
 @pytest.fixture
+def cdk2_receptor_traj(cdk2_receptor) -> mdtraj.Trajectory:
+    return _structure_to_mdtraj(cdk2_receptor)
+
+
+@pytest.fixture
 def cdk2_ligand_1() -> parmed.amber.AmberParm:
     return parmed.amber.AmberParm(
         str(CDK2_SYSTEM.ligand_1_params), str(CDK2_SYSTEM.ligand_1_coords)
     )
+
+
+@pytest.fixture
+def cdk2_ligand_1_traj(cdk2_ligand_1) -> mdtraj.Trajectory:
+    return _structure_to_mdtraj(cdk2_ligand_1)
 
 
 @pytest.fixture
@@ -39,6 +51,11 @@ def cdk2_ligand_2() -> parmed.amber.AmberParm:
     return parmed.amber.AmberParm(
         str(CDK2_SYSTEM.ligand_2_params), str(CDK2_SYSTEM.ligand_2_coords)
     )
+
+
+@pytest.fixture
+def cdk2_ligand_2_traj(cdk2_ligand_2) -> mdtraj.Trajectory:
+    return _structure_to_mdtraj(cdk2_ligand_2)
 
 
 def test_queries_to_idxs(cdk2_ligand_1):
@@ -194,14 +211,16 @@ def test_select_ligand_idxs_two_ligands(
     assert ligand_2_idxs == expected_ligand_2_idxs
 
 
-def test_filter_receptor_atoms(cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs):
+def test_filter_receptor_atoms(
+    cdk2_receptor_traj, cdk2_ligand_1_traj, cdk2_ligand_1_ref_idxs
+):
     # computed using the reference SepTop implementation at commit 7af0b4d
     # fmt: off
     expected_idxs = [380, 381, 382, 383, 384, 388, 389, 390, 391, 392, 399, 400, 401, 402, 403, 408, 409, 410, 411, 412, 830, 831, 832, 833, 834, 838, 839, 840, 841, 842, 847, 848, 849, 850, 851, 853, 854, 855, 856, 857, 865, 866, 867, 868, 869, 873, 874, 875, 876, 877, 884, 885, 886, 887, 888, 893, 894, 895, 896, 897, 901, 902, 903, 904, 905, 909, 910, 911, 912, 913, 918, 919, 920, 921, 922, 923, 924, 925, 926, 930, 931, 932, 933, 934, 935, 936, 937, 938, 939, 1494, 1495, 1496, 1497, 1498, 1502, 1503, 1504, 1505, 1506, 1516, 1517, 1518, 1519, 1520, 1522, 1523, 1524, 1525, 1526, 1530, 1531, 1532, 1533, 1534, 1535, 1536, 1537, 1538, 1540, 1541, 1542, 1543, 1544, 1548, 1549, 1550, 1551, 1552, 1559, 1560, 1561, 1562, 1563, 1564, 1565, 1566, 1567, 1568, 1691, 1692, 1693, 1694, 1695, 1723, 1734, 2109, 2110, 2111, 2112, 2116, 2117, 2118, 2119, 2120]  # noqa: E201,E221,E241,E501
     # fmt: on
 
     receptor_idxs = femto.fe.reference._filter_receptor_atoms(
-        cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs[0]
+        cdk2_receptor_traj, cdk2_ligand_1_traj, cdk2_ligand_1_ref_idxs[0]
     )
     assert receptor_idxs == expected_idxs
 
@@ -318,7 +337,9 @@ def test_is_valid_r1(
     spied_linear = mocker.spy(femto.fe.reference, "_is_angle_linear")
     spied_trans = mocker.spy(femto.fe.reference, "_is_dihedral_trans")
 
-    is_valid = femto.fe.reference._is_valid_r1(receptor, 0, ligand, (0, 1, 2))
+    is_valid = femto.fe.reference._is_valid_r1(
+        _structure_to_mdtraj(receptor), 0, _structure_to_mdtraj(ligand), (0, 1, 2)
+    )
     assert is_valid == expected_valid
 
     assert spied_collinear.spy_return == expected_collinear
@@ -415,7 +436,11 @@ def test_is_valid_r2(
     spied_trans = mocker.spy(femto.fe.reference, "_is_dihedral_trans")
 
     is_valid = femto.fe.reference._is_valid_r2(
-        receptor, 1, receptor_ref_idx, ligand, (0, 1, 2)
+        _structure_to_mdtraj(receptor),
+        1,
+        receptor_ref_idx,
+        _structure_to_mdtraj(ligand),
+        (0, 1, 2),
     )
     assert is_valid == expected_valid
 
@@ -486,7 +511,12 @@ def test_is_valid_r3(
     spied_trans = mocker.spy(femto.fe.reference, "_is_dihedral_trans")
 
     is_valid = femto.fe.reference._is_valid_r3(
-        receptor, 2, receptor_ref_idxs[0], receptor_ref_idxs[1], ligand, (0, 1, 2)
+        _structure_to_mdtraj(receptor),
+        2,
+        receptor_ref_idxs[0],
+        receptor_ref_idxs[1],
+        _structure_to_mdtraj(ligand),
+        (0, 1, 2),
     )
     assert is_valid == expected_valid
 

--- a/femto/fe/tests/test_reference.py
+++ b/femto/fe/tests/test_reference.py
@@ -529,10 +529,8 @@ def test_select_receptor_idxs(cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_id
 
     x, _ = select_ligand_idxs(cdk2_ligand_1, None, "baumann")
 
-    # computed using the reference SepTop implementation at commit 7af0b4d
-    # note there will be some differences due to the different r3 distance calculation
-    # and also the bug with the SepTop implementation of are collinear.
-    expected_receptor_idxs = 830, 841, 384
+    # computed using the reference SepTop implementation at commit 3705ba5
+    expected_receptor_idxs = 830, 841, 399
 
     receptor_idxs = femto.fe.reference.select_receptor_idxs(
         cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs

--- a/femto/md/reporting/openmm.py
+++ b/femto/md/reporting/openmm.py
@@ -129,7 +129,7 @@ class OpenMMStateReporter:
                 else (
                     2
                     * state.getKineticEnergy()
-                    / (self._dof * openmm.unit.MOLAR_GAS_CONSTANT_R)
+                    / (max(1.0, self._dof) * openmm.unit.MOLAR_GAS_CONSTANT_R)
                 )
             )
 


### PR DESCRIPTION
## Description

This PR aims to fix the automatic receptor reference selection code. Namely it:

* adds the option to provide trajectories, and implements the variance checks described in the original paper
* fixes a possible indexing issue in `_filter_receptor_atoms`
* fixes idxs passed in the wrong order when creating Boresch style restraints
* allows using difference receptor ref atoms for ligand 1 and 2 if the same set of ref atoms don't satisfy the criteria outlined by Baumann et al

## TODO

- [x] Add tests

## Status
- [x] Ready to go
