### PR TITLE
Support PMX-style receptor reference atom selection

### DIFF
--- a/examples/eralpha/config-septop.yaml
+++ b/examples/eralpha/config-septop.yaml
@@ -25,6 +25,9 @@ complex:
       k_dihedral_c: 20.0 kcal * rad**-2 * mol**-1
       scale_k_angle_a: true
 
+      atom_selection_receptor: baumann
+      atom_selection_ligand:   baumann
+
     apply_hmr: true
     hydrogen_mass: 1.5 Da
 

--- a/femto/fe/config.py
+++ b/femto/fe/config.py
@@ -19,6 +19,11 @@ LigandReferenceMethod = typing.Literal["chen", "baumann"]
 restraints."""
 
 
+ReceptorReferenceMethod = typing.Literal["baumann", "pmx"]
+"""The method to use when automatically selecting protein atoms to use in ligand
+alignment restraints."""
+
+
 class FEP(femto.md.utils.models.BaseModel):
     """Configure modifying a system to be scalable by FEP lambdas."""
 

--- a/femto/fe/septop/_config.py
+++ b/femto/fe/septop/_config.py
@@ -76,6 +76,17 @@ class SepTopComplexRestraints(femto.md.config.BoreschRestraint):
         "based upon the *initial* distance between r3 and l1.",
     )
 
+    atom_selection_receptor: femto.fe.config.ReceptorReferenceMethod = pydantic.Field(
+        "baumann",
+        description="The method to use when automatically selecting the protein atoms "
+        "to use in the restraint.",
+    )
+    atom_selection_ligand: typing.Literal["baumann"] = pydantic.Field(
+        "baumann",
+        description="The method to use when automatically selecting the ligand atoms "
+        "to use in the restraint.",
+    )
+
 
 class SepTopSolutionRestraints(BaseModel):
     """Configure the restraints to apply in the solution phase."""

--- a/femto/fe/tests/test_reference.py
+++ b/femto/fe/tests/test_reference.py
@@ -524,18 +524,30 @@ def test_is_valid_r3(
     assert spied_trans.spy_return == expected_dihedral_trans
 
 
-def test_select_receptor_idxs(cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs):
+def test_select_receptor_idxs_baumann(
+    cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs
+):
     # computed using the reference SepTop implementation at commit 3705ba5
     expected_receptor_idxs = 830, 841, 399
 
     receptor_idxs = femto.fe.reference.select_receptor_idxs(
-        cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs
+        cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs, method="baumann"
     )
     assert receptor_idxs == expected_receptor_idxs
 
     assert femto.fe.reference.check_receptor_idxs(
         cdk2_receptor, receptor_idxs, cdk2_ligand_1, cdk2_ligand_1_ref_idxs
     )
+
+
+def test_select_receptor_idxs_pmx(cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs):
+    # visually inspected to ensure the selection looks sensible.
+    expected_receptor_idxs = 250, 247, 251
+
+    receptor_idxs = femto.fe.reference.select_receptor_idxs(
+        cdk2_receptor, cdk2_ligand_1, cdk2_ligand_1_ref_idxs, method="pmx"
+    )
+    assert receptor_idxs == expected_receptor_idxs
 
 
 def test_select_protein_cavity_atoms(cdk2_receptor, cdk2_ligand_1, cdk2_ligand_2):

--- a/femto/md/restraints.py
+++ b/femto/md/restraints.py
@@ -183,7 +183,21 @@ def create_boresch_restraint(
     coords: openmm.unit.Quantity,
     ctx_parameter: str | None = None,
 ) -> openmm.CustomCompoundBondForce:
-    """Creates a Boresch restraint force useful in aligning a receptor and ligand.
+    """Creates a Boresch-style restraint force useful in aligning a receptor and ligand.
+
+    This includes:
+
+    * a distance restraint between ``receptor_atoms[2]`` and ``ligand_atoms[0]``,
+    * an angle restraint between ``receptor_atoms[1]``, ``receptor_atoms[2]``, and
+      ``ligand_atoms[0]``,
+    * an angle restraint between ``receptor_atoms[2]``, ``ligand_atoms[0]``, and
+      ``ligand_atoms[1]``,
+    * a dihedral restraint between ``receptor_atoms[0]``, ``receptor_atoms[1]``,
+      ``receptor_atoms[2]``, and ``ligand_atoms[0]``,
+    * a dihedral restraint between ``receptor_atoms[1]``, ``receptor_atoms[2]``,
+      ``ligand_atoms[0]``, and ``ligand_atoms[1]``,
+    * a dihedral restraint between ``receptor_atoms[2]``, ``ligand_atoms[0]``,
+      ``ligand_atoms[1]``, and ``ligand_atoms[2]``.
 
     Args:
         config: The restraint configuration.


### PR DESCRIPTION
## Description

This PR adds support for an alternative method for selecting receptor atoms for use in the alignment restraints, based on PMX at commit 3b135ad

## Status
- [X] Ready to go
