### PR TITLE
Check receptor coords are provided to CLI

### DIFF
--- a/femto/fe/atm/_cli.py
+++ b/femto/fe/atm/_cli.py
@@ -4,6 +4,7 @@ import logging
 import pathlib
 import shlex
 
+import click
 import cloup
 import numpy
 import openmm.unit
@@ -179,6 +180,11 @@ def _run_workflow_cli(
         ligand_2_coords = edge.ligand_2.coords
         ligand_2_params = edge.ligand_2.params
         ligand_2_ref_atoms = edge.ligand_2.metadata["ref_atoms"]
+    else:
+        if receptor_coords is None:
+            raise click.UsageError("The receptor coordinates must be provided")
+        if ligand_1_coords is None:
+            raise click.UsageError("The ligand coordinates must be provided")
 
     ligand_displacement = (
         ligand_displacement

--- a/femto/fe/septop/_cli.py
+++ b/femto/fe/septop/_cli.py
@@ -4,6 +4,7 @@ import logging
 import pathlib
 import shlex
 
+import click
 import cloup
 import openmm
 import yaml
@@ -270,6 +271,11 @@ def _run_complex_cli(
         ligand_2_coords = edge.ligand_2.coords
         ligand_2_params = edge.ligand_2.params
         # ligand_2_ref_atoms = edge.ligand_2.metadata["ref_atoms"]
+    else:
+        if receptor_coords is None:
+            raise click.UsageError("The receptor coordinates must be provided")
+        if ligand_1_coords is None:
+            raise click.UsageError("The ligand coordinates must be provided")
 
     # handle cases where multiple simulations should be stacked on a single GPU
     femto.md.utils.mpi.divide_gpus()

--- a/femto/fe/tests/atm/test_cli.py
+++ b/femto/fe/tests/atm/test_cli.py
@@ -101,6 +101,33 @@ def test_run_workflow_with_paths(click_runner, mock_cuda_devices, tmp_cwd, mocke
     )
 
 
+def test_run_workflow_missing_path(click_runner, mock_cuda_devices, tmp_cwd):
+    mock_args = [
+        "run-workflow",
+        "--ligand-1-coords",
+        TEMOA_SYSTEM.ligand_1_coords,
+        "--ligand-1-params",
+        TEMOA_SYSTEM.ligand_1_params,
+        "--ligand-1-ref-atoms",
+        *TEMOA_SYSTEM.ligand_1_ref_atoms,
+        "--ligand-2-coords",
+        TEMOA_SYSTEM.ligand_2_coords,
+        "--ligand-2-params",
+        TEMOA_SYSTEM.ligand_2_params,
+        "--ligand-2-ref-atoms",
+        *TEMOA_SYSTEM.ligand_2_ref_atoms,
+        "--output-dir",
+        ".",
+    ]
+
+    result: click.testing.Result = click_runner.invoke(
+        typing.cast(click.Command, main_cli), mock_args
+    )
+
+    assert result.exit_code == 2
+    assert "The receptor coordinates must be provided" in result.output
+
+
 def test_run_workflow_with_directory(
     click_runner, mock_cuda_devices, tmp_cwd, mock_bfe_directory, mocker
 ):

--- a/femto/fe/tests/septop/test_cli.py
+++ b/femto/fe/tests/septop/test_cli.py
@@ -195,6 +195,33 @@ def test_run_complex_with_paths(click_runner, mock_cuda_devices, tmp_cwd, mocker
     )
 
 
+def test_run_complex_missing_path(click_runner, mock_cuda_devices, tmp_cwd):
+    mock_args = [
+        "run-complex",
+        "--ligand-1-coords",
+        TEMOA_SYSTEM.ligand_1_coords,
+        "--ligand-1-params",
+        TEMOA_SYSTEM.ligand_1_params,
+        "--ligand-1-ref-atoms",
+        *TEMOA_SYSTEM.ligand_1_ref_atoms,
+        "--ligand-2-coords",
+        TEMOA_SYSTEM.ligand_2_coords,
+        "--ligand-2-params",
+        TEMOA_SYSTEM.ligand_2_params,
+        "--ligand-2-ref-atoms",
+        *TEMOA_SYSTEM.ligand_2_ref_atoms,
+        "--output-dir",
+        ".",
+    ]
+
+    result: click.testing.Result = click_runner.invoke(
+        typing.cast(click.Command, main_cli), mock_args
+    )
+
+    assert result.exit_code == 2
+    assert "The receptor coordinates must be provided" in result.output
+
+
 def test_run_complex_with_directory(
     click_runner, mock_cuda_devices, tmp_cwd, mock_bfe_directory, mocker
 ):


### PR DESCRIPTION
## Description

Currently the CLI doesn't check if you provide both the ligand and receptor paths are provided, which leads to more obscure errors down the code path.

## Status
- [X] Ready to go
