### PR TITLE
Fix multi-process HREMD coordinate reduce

### DIFF
--- a/femto/md/hremd.py
+++ b/femto/md/hremd.py
@@ -754,7 +754,7 @@ def run_hremd(
         mpi_comm.barrier()
 
         coords_dict = {i + replica_idx_offset: coord for i, coord in enumerate(coords)}
-        coords_dict = femto.md.utils.mpi.reduce_dict(coords_dict, mpi_comm, root=0)
+        coords_dict = femto.md.utils.mpi.reduce_dict(coords_dict, mpi_comm, root=None)
 
         final_coords = [coords_dict[replica_to_state_idx[i]] for i in range(n_states)]
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the final coordinates from HREMD would only be sent to rank 0, rather than all ranks leading to a 'cannot index `None`' error when using multiple ranks.

I tested locally with 2 ranks and this fix resolved the issue.

## Status
- [X] Ready to go
