### PR TITLE
Fix indexing of ligand 2

### DIFF
--- a/femto/fe/septop/_setup.py
+++ b/femto/fe/septop/_setup.py
@@ -241,7 +241,9 @@ def setup_complex(
         )
         receptor_ref_idxs_2 = receptor_ref_idxs_1
 
-        # Remove the offset and check use ligand 2 indices with ligand 2.
+        # Remove the offset of ligand 2 atom indices.
+        # `ligand_2_ref_idxs` should be in the range 0:ligand_2.atoms to match
+        # `ligand_2` parmed.amber.AmberParm.
         _ligand_2_ref_idxs = tuple(i - len(ligand_1.atoms) for i in ligand_2_ref_idxs)
         if ligand_2 is not None and not femto.fe.reference.check_receptor_idxs(
             receptor, receptor_ref_idxs_1, ligand_2, _ligand_2_ref_idxs

--- a/femto/fe/septop/_setup.py
+++ b/femto/fe/septop/_setup.py
@@ -241,12 +241,14 @@ def setup_complex(
         )
         receptor_ref_idxs_2 = receptor_ref_idxs_1
 
+        # Remove the offset and check use ligand 2 indices with ligand 2.
+        _ligand_2_ref_idxs = tuple(i - len(ligand_1.atoms) for i in ligand_2_ref_idxs)
         if ligand_2 is not None and not femto.fe.reference.check_receptor_idxs(
-            receptor, receptor_ref_idxs_1, ligand_2, ligand_1_ref_idxs
+            receptor, receptor_ref_idxs_1, ligand_2, _ligand_2_ref_idxs
         ):
             _LOGGER.info("selecting alternate receptor reference atoms for ligand 2")
             receptor_ref_idxs_2 = femto.fe.reference.select_receptor_idxs(
-                receptor, ligand_2, ligand_2_ref_idxs
+                receptor, ligand_2, _ligand_2_ref_idxs
             )
 
     else:


### PR DESCRIPTION
## Description
There are two bugs, I think. See #15.

1. The first bug is using `ligand_1_ref_idxs` with `ligand_2` when checking for receptor reference atoms.
2. The second bug happens when naively replacing `ligand_1_ref_idxs` with `ligand_2_ref_idxs`. The reference indices for ligand 2 are offset by the number of atoms in ligand 1 (I guess this probably happens to index into a combined topology of both ligands at some point in the code). But `check_receptor_idxs` will eventually try to index the provided ligand with the provided index. So, before calling this function, the indices need to be "un-offset" so you don't end up with an `IndexError`.

## Status
- [X] Ready to go
