### PR TITLE
Clean-up logging from private modules

### DIFF
--- a/femto/fe/_cli.py
+++ b/femto/fe/_cli.py
@@ -1,15 +1,14 @@
 """Command-line interface for ``femto``."""
 
-import logging
-
 import cloup
 
 import femto.fe.atm._cli
 import femto.fe.septop._cli
 import femto.fe.utils.cli
+import femto.md.utils.logging
 import femto.md.utils.mpi
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = femto.md.utils.logging.get_parent_logger(__package__)
 
 
 @cloup.group()

--- a/femto/fe/atm/_cli.py
+++ b/femto/fe/atm/_cli.py
@@ -1,6 +1,5 @@
 """Command line interface for femto atm."""
 
-import logging
 import pathlib
 import shlex
 
@@ -16,9 +15,10 @@ import femto.fe.inputs
 import femto.fe.utils.cli
 import femto.fe.utils.queue
 import femto.md.config
+import femto.md.utils.logging
 import femto.md.utils.mpi
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = femto.md.utils.logging.get_parent_logger(__package__)
 
 
 _RECEPTOR_OPTIONS = [

--- a/femto/fe/atm/_equilibrate.py
+++ b/femto/fe/atm/_equilibrate.py
@@ -1,7 +1,6 @@
 """Equilibration stage of the ATM free energy calculation."""
 
 import copy
-import logging
 import typing
 
 import mdtop
@@ -12,12 +11,13 @@ import femto.md.constants
 import femto.md.reporting
 import femto.md.reporting.openmm
 import femto.md.simulate
+import femto.md.utils.logging
 
 if typing.TYPE_CHECKING:
     import femto.fe.atm
 
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = femto.md.utils.logging.get_parent_logger(__package__)
 
 
 def equilibrate_states(

--- a/femto/fe/atm/_runner.py
+++ b/femto/fe/atm/_runner.py
@@ -1,7 +1,6 @@
 """Helpers to run ATM calculations."""
 
 import datetime
-import logging
 import pathlib
 import typing
 
@@ -16,12 +15,13 @@ import femto.fe.utils.queue
 import femto.md.constants
 import femto.md.prepare
 import femto.md.reporting
+import femto.md.utils.logging
 import femto.md.utils.mpi
 
 if typing.TYPE_CHECKING:
     import femto.fe.atm
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = femto.md.utils.logging.get_parent_logger(__package__)
 
 
 @femto.md.utils.mpi.run_on_rank_zero

--- a/femto/fe/atm/_sample.py
+++ b/femto/fe/atm/_sample.py
@@ -2,7 +2,6 @@
 
 import copy
 import functools
-import logging
 import pathlib
 import typing
 
@@ -13,12 +12,13 @@ import openmm
 import femto.md.constants
 import femto.md.hremd
 import femto.md.reporting
+import femto.md.utils.logging
 import femto.md.utils.openmm
 
 if typing.TYPE_CHECKING:
     import femto.fe.atm
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = femto.md.utils.logging.get_parent_logger(__package__)
 
 
 def _analyze(

--- a/femto/fe/atm/_setup.py
+++ b/femto/fe/atm/_setup.py
@@ -1,7 +1,6 @@
 """Set up the system for ATM calculations."""
 
 import copy
-import logging
 import pathlib
 import typing
 
@@ -16,13 +15,14 @@ import femto.fe.reference
 import femto.md.prepare
 import femto.md.rest
 import femto.md.restraints
+import femto.md.utils.logging
 import femto.md.utils.openmm
 from femto.md.constants import OpenMMForceGroup, OpenMMForceName
 
 if typing.TYPE_CHECKING:
     import femto.fe.atm
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = femto.md.utils.logging.get_parent_logger(__package__)
 
 
 def select_displacement(

--- a/femto/fe/septop/_cli.py
+++ b/femto/fe/septop/_cli.py
@@ -1,6 +1,5 @@
 """Command line interface for femto septop."""
 
-import logging
 import pathlib
 import shlex
 
@@ -14,9 +13,10 @@ import femto.fe.inputs
 import femto.fe.utils.cli
 import femto.fe.utils.queue
 import femto.md.config
+import femto.md.utils.logging
 import femto.md.utils.mpi
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = femto.md.utils.logging.get_parent_logger(__package__)
 
 
 _RECEPTOR_OPTIONS = [

--- a/femto/fe/septop/_equilibrate.py
+++ b/femto/fe/septop/_equilibrate.py
@@ -1,6 +1,5 @@
 """Equilibration stage of the SepTop free energy calculation."""
 
-import logging
 import typing
 
 import mdtop
@@ -10,11 +9,12 @@ import femto.md.constants
 import femto.md.reporting
 import femto.md.reporting.openmm
 import femto.md.simulate
+import femto.md.utils.logging
 
 if typing.TYPE_CHECKING:
     import femto.fe.septop
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = femto.md.utils.logging.get_parent_logger(__package__)
 
 
 def equilibrate_states(

--- a/femto/fe/septop/_sample.py
+++ b/femto/fe/septop/_sample.py
@@ -2,7 +2,6 @@
 
 import copy
 import functools
-import logging
 import pathlib
 import typing
 
@@ -14,12 +13,13 @@ import femto.fe.ddg
 import femto.md.constants
 import femto.md.hremd
 import femto.md.reporting
+import femto.md.utils.logging
 import femto.md.utils.openmm
 
 if typing.TYPE_CHECKING:
     import femto.fe.septop
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = femto.md.utils.logging.get_parent_logger(__package__)
 
 _KJ_PER_MOL = openmm.unit.kilojoules_per_mole
 

--- a/femto/fe/septop/_setup.py
+++ b/femto/fe/septop/_setup.py
@@ -1,7 +1,6 @@
 """Set up the system for SepTop calculations."""
 
 import copy
-import logging
 import pathlib
 
 import mdtop
@@ -16,9 +15,10 @@ import femto.md.constants
 import femto.md.prepare
 import femto.md.rest
 import femto.md.restraints
+import femto.md.utils.logging
 import femto.md.utils.openmm
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER = femto.md.utils.logging.get_parent_logger(__package__)
 
 
 _ANGSTROM = openmm.unit.angstrom

--- a/femto/md/utils/logging.py
+++ b/femto/md/utils/logging.py
@@ -1,0 +1,34 @@
+"""Utilities to setup logging"""
+
+import logging
+
+
+def get_public_parent_module(name: str) -> str:
+    """Get the first public parent module of a module.
+
+    Args:
+        name: The full name (e.g. ``'mod_a.mod_b._mod_c'``) of the module.
+
+    Returns:
+        The full name of the first public parent module (e.g. ``'mod_a.mod_b'``).
+    """
+
+    parts = name.split(".")
+
+    while parts and parts[-1].startswith("_"):
+        parts.pop()
+
+    return ".".join(parts)
+
+
+def get_parent_logger(name: str) -> logging.Logger:
+    """Returns the logger of the first public parent module of a module.
+
+    Args:
+        name: The full name (e.g. ``'mod_a.mod_b._mod_c'``) of the module.
+
+    Returns:
+        The logger.
+    """
+
+    return logging.getLogger(get_public_parent_module(name))


### PR DESCRIPTION
## Description

Previously the logger would say something like `femto.fe.septop._setup: INFO` for the module name of private modules, but now it will just say `femto.fe.septop: INFO`

## Status
- [X] Ready to go
