### PR TITLE
[FE] Use robust MBAR solver

### DIFF
--- a/femto/fe/ddg.py
+++ b/femto/fe/ddg.py
@@ -90,7 +90,7 @@ def _estimate_f_i(
     import pymbar.timeseries
 
     try:
-        mbar = pymbar.MBAR(u_kn, n_k)
+        mbar = pymbar.MBAR(u_kn, n_k, solver_protocol="robust")
         ddg_dict = mbar.compute_free_energy_differences()
 
         return ddg_dict["Delta_f"][0, :], ddg_dict["dDelta_f"][0, :] ** 2, mbar.W_nk


### PR DESCRIPTION
## Description

The default solver changed to a faster, [but also less robust](https://github.com/choderalab/pymbar/issues/544) solver In newer versions of `pymbar`. For now we always use the older but more robust MBAR solver to avoid spurious errors and incorrect free energies in certain cases.

## Status
- [X] Ready to go
