### PR TITLE
 Implement GPU Oversubscription via CUDA MPS for HREMD Throughput Optimization

### DIFF
--- a/femto/fe/septop/_cli.py
+++ b/femto/fe/septop/_cli.py
@@ -136,6 +136,14 @@ def _print_config(context: cloup.Context):
 @femto.fe.utils.cli.add_options(femto.fe.utils.cli.DEFAULT_LIGAND_PATHS_GROUP)
 @femto.fe.utils.cli.add_options(femto.fe.utils.cli.DEFAULT_LIGAND_OPTIONS_GROUP)
 @femto.fe.utils.cli.add_options(femto.fe.utils.cli.DEFAULT_OUTPUTS_GROUP)
+@cloup.option(
+    "--oversubscribe",
+    type=int,
+    default=None,
+    help="Number of MPI ranks to run per GPU using CUDA MPS. When set, "
+    "automatically starts/stops the MPS daemon and launches under mpirun "
+    "with n_gpus * N total ranks.",
+)
 @cloup.pass_context
 def _run_solution_cli(
     context: cloup.Context,
@@ -151,10 +159,17 @@ def _run_solution_cli(
     ligand_2_ref_atoms: tuple[str, str, str] | None,
     output_dir: pathlib.Path,
     report_dir: pathlib.Path | None,
+    oversubscribe: int | None,
 ):
     import femto.fe.septop
 
     config = context.obj
+
+    # If --oversubscribe is set and we're not already inside MPI, re-launch
+    # under mpirun with MPS enabled and exit.
+    if oversubscribe is not None and not femto.md.utils.mpi.is_inside_mpi():
+        rc = femto.md.utils.mpi.launch_with_mps(oversubscribe)
+        raise SystemExit(rc)
 
     using_directory, _ = femto.fe.utils.cli.validate_mutually_exclusive_groups(
         context,
@@ -209,6 +224,14 @@ def _run_solution_cli(
 @femto.fe.utils.cli.add_options(femto.fe.utils.cli.DEFAULT_RECEPTOR_PATHS_GROUP)
 @femto.fe.utils.cli.add_options(_RECEPTOR_OPTIONS_GROUP)
 @femto.fe.utils.cli.add_options(femto.fe.utils.cli.DEFAULT_OUTPUTS_GROUP)
+@cloup.option(
+    "--oversubscribe",
+    type=int,
+    default=None,
+    help="Number of MPI ranks to run per GPU using CUDA MPS. When set, "
+    "automatically starts/stops the MPS daemon and launches under mpirun "
+    "with n_gpus * N total ranks.",
+)
 @cloup.pass_context
 def _run_complex_cli(
     context: cloup.Context,
@@ -227,10 +250,17 @@ def _run_complex_cli(
     ligand_2_ref_atoms: tuple[str, str, str] | None,
     output_dir: pathlib.Path,
     report_dir: pathlib.Path | None,
+    oversubscribe: int | None,
 ):
     import femto.fe.septop
 
     config = context.obj
+
+    # If --oversubscribe is set and we're not already inside MPI, re-launch
+    # under mpirun with MPS enabled and exit.
+    if oversubscribe is not None and not femto.md.utils.mpi.is_inside_mpi():
+        rc = femto.md.utils.mpi.launch_with_mps(oversubscribe)
+        raise SystemExit(rc)
 
     using_directory, _ = femto.fe.utils.cli.validate_mutually_exclusive_groups(
         context,

--- a/femto/md/tests/utils/test_mpi.py
+++ b/femto/md/tests/utils/test_mpi.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import signal
 
 import pytest
@@ -132,3 +133,223 @@ def test_run_on_rank_zero():
 
     return_value = dummy_func(2)
     assert return_value == 4
+
+
+class TestIsInsideMpi:
+    def test_not_inside_mpi(self, mocker):
+        mocker.patch.dict(os.environ, {}, clear=True)
+        assert femto.md.utils.mpi.is_inside_mpi() is False
+
+    @pytest.mark.parametrize("env_var", ["PMI_RANK", "PMIX_RANK", "OMPI_COMM_WORLD_SIZE"])
+    def test_inside_mpi(self, env_var, mocker):
+        mocker.patch.dict(os.environ, {env_var: "0"}, clear=True)
+        assert femto.md.utils.mpi.is_inside_mpi() is True
+
+
+class TestIsMpsRunning:
+    def test_no_mps_control_binary(self, mocker):
+        mocker.patch("shutil.which", return_value=None)
+        assert femto.md.utils.mpi.is_mps_running() is False
+
+    def test_mps_running(self, mocker):
+        mocker.patch("shutil.which", return_value="/usr/bin/nvidia-cuda-mps-control")
+        mocker.patch(
+            "subprocess.run",
+            return_value=mocker.MagicMock(returncode=0),
+        )
+        assert femto.md.utils.mpi.is_mps_running() is True
+
+    def test_mps_not_running(self, mocker):
+        mocker.patch("shutil.which", return_value="/usr/bin/nvidia-cuda-mps-control")
+        mocker.patch(
+            "subprocess.run",
+            return_value=mocker.MagicMock(returncode=1),
+        )
+        assert femto.md.utils.mpi.is_mps_running() is False
+
+
+class TestStartStopMps:
+    def test_start_mps_no_binary(self, mocker):
+        mocker.patch("shutil.which", return_value=None)
+        with pytest.raises(RuntimeError, match="nvidia-cuda-mps-control not found"):
+            femto.md.utils.mpi.start_mps()
+
+    def test_start_mps_already_running(self, mocker):
+        mocker.patch("shutil.which", return_value="/usr/bin/nvidia-cuda-mps-control")
+        mocker.patch("femto.md.utils.mpi.is_mps_running", return_value=True)
+        mock_run = mocker.patch("subprocess.run")
+
+        femto.md.utils.mpi.start_mps()
+
+        # Should not have called nvidia-cuda-mps-control -d
+        mock_run.assert_not_called()
+
+    def test_start_mps(self, mocker):
+        mocker.patch("shutil.which", return_value="/usr/bin/nvidia-cuda-mps-control")
+        mocker.patch("femto.md.utils.mpi.is_mps_running", return_value=False)
+        mock_run = mocker.patch("subprocess.run")
+
+        femto.md.utils.mpi.start_mps()
+
+        mock_run.assert_called_once_with(
+            ["nvidia-cuda-mps-control", "-d"], check=True
+        )
+
+    def test_stop_mps(self, mocker):
+        mock_run = mocker.patch("subprocess.run")
+
+        femto.md.utils.mpi.stop_mps()
+
+        mock_run.assert_called_once_with(
+            ["nvidia-cuda-mps-control"],
+            input="quit\n",
+            text=True,
+            check=False,
+            timeout=10,
+        )
+
+
+class TestMpsContext:
+    def test_starts_and_stops_mps(self, mocker):
+        mocker.patch("femto.md.utils.mpi.is_mps_running", return_value=False)
+        mock_start = mocker.patch("femto.md.utils.mpi.start_mps")
+        mock_stop = mocker.patch("femto.md.utils.mpi.stop_mps")
+
+        with femto.md.utils.mpi.mps_context():
+            mock_start.assert_called_once()
+
+        mock_stop.assert_called_once()
+
+    def test_skips_if_already_running(self, mocker):
+        mocker.patch("femto.md.utils.mpi.is_mps_running", return_value=True)
+        mock_start = mocker.patch("femto.md.utils.mpi.start_mps")
+        mock_stop = mocker.patch("femto.md.utils.mpi.stop_mps")
+
+        with femto.md.utils.mpi.mps_context():
+            mock_start.assert_not_called()
+
+        mock_stop.assert_not_called()
+
+    def test_stops_on_exception(self, mocker):
+        mocker.patch("femto.md.utils.mpi.is_mps_running", return_value=False)
+        mocker.patch("femto.md.utils.mpi.start_mps")
+        mock_stop = mocker.patch("femto.md.utils.mpi.stop_mps")
+
+        with pytest.raises(RuntimeError):
+            with femto.md.utils.mpi.mps_context():
+                raise RuntimeError("test")
+
+        mock_stop.assert_called_once()
+
+
+class TestStripOversubscribeFromArgv:
+    def test_strip_separate_args(self):
+        argv = ["femto", "septop", "run-complex", "--oversubscribe", "4", "--output-dir", "/tmp"]
+        result = femto.md.utils.mpi._strip_oversubscribe_from_argv(argv)
+        assert result == ["femto", "septop", "run-complex", "--output-dir", "/tmp"]
+
+    def test_strip_equals_form(self):
+        argv = ["femto", "septop", "run-complex", "--oversubscribe=4", "--output-dir", "/tmp"]
+        result = femto.md.utils.mpi._strip_oversubscribe_from_argv(argv)
+        assert result == ["femto", "septop", "run-complex", "--output-dir", "/tmp"]
+
+    def test_no_oversubscribe(self):
+        argv = ["femto", "septop", "run-complex", "--output-dir", "/tmp"]
+        result = femto.md.utils.mpi._strip_oversubscribe_from_argv(argv)
+        assert result == argv
+
+
+class TestLaunchWithMps:
+    def test_no_gpus(self, mocker):
+        mocker.patch("femto.md.utils.mpi._count_cuda_devices", return_value=0)
+
+        with pytest.raises(RuntimeError, match="No CUDA devices found"):
+            femto.md.utils.mpi.launch_with_mps(2)
+
+    def test_no_mpirun(self, mocker):
+        mocker.patch("femto.md.utils.mpi._count_cuda_devices", return_value=2)
+        mocker.patch("shutil.which", return_value=None)
+        mocker.patch("sys.argv", ["femto", "septop", "run-complex"])
+
+        with pytest.raises(RuntimeError, match="Cannot find mpirun"):
+            femto.md.utils.mpi.launch_with_mps(2)
+
+    def test_launch_auto_detect_mpi(self, mocker):
+        mocker.patch("femto.md.utils.mpi._count_cuda_devices", return_value=2)
+        mocker.patch(
+            "shutil.which",
+            side_effect=lambda cmd: "/usr/bin/mpirun" if cmd == "mpirun" else None,
+        )
+        mocker.patch(
+            "sys.argv",
+            ["femto", "septop", "run-complex", "--oversubscribe", "4", "--output-dir", "/tmp"],
+        )
+        mock_mps_ctx = mocker.patch("femto.md.utils.mpi.mps_context")
+        mock_mps_ctx.return_value.__enter__ = mocker.MagicMock()
+        mock_mps_ctx.return_value.__exit__ = mocker.MagicMock(return_value=False)
+
+        mock_run = mocker.patch(
+            "subprocess.run",
+            return_value=mocker.MagicMock(returncode=0),
+        )
+
+        rc = femto.md.utils.mpi.launch_with_mps(4)
+
+        assert rc == 0
+
+        # Should launch with 2 GPUs * 4 = 8 ranks
+        call_args = mock_run.call_args
+        cmd = call_args[0][0]
+        assert cmd[:4] == ["/usr/bin/mpirun", "-n", "8", "--oversubscribe"]
+        # --oversubscribe should be stripped from the child argv
+        assert "--oversubscribe" not in cmd[4:]
+        assert "4" not in cmd[4:] or cmd[4:].index("4") != cmd[4:].index("--oversubscribe") + 1 if "--oversubscribe" in cmd[4:] else True
+
+        # CUDA_MPS_ACTIVE_THREAD_PERCENTAGE should be 200 // 4 = 50
+        env = call_args[1]["env"]
+        assert env["CUDA_MPS_ACTIVE_THREAD_PERCENTAGE"] == "50"
+
+    def test_launch_custom_mpi_command(self, mocker):
+        mocker.patch("femto.md.utils.mpi._count_cuda_devices", return_value=1)
+        mocker.patch("sys.argv", ["femto", "septop", "run-complex", "--output-dir", "/tmp"])
+        mock_mps_ctx = mocker.patch("femto.md.utils.mpi.mps_context")
+        mock_mps_ctx.return_value.__enter__ = mocker.MagicMock()
+        mock_mps_ctx.return_value.__exit__ = mocker.MagicMock(return_value=False)
+
+        mock_run = mocker.patch(
+            "subprocess.run",
+            return_value=mocker.MagicMock(returncode=0),
+        )
+
+        rc = femto.md.utils.mpi.launch_with_mps(2, mpi_command="srun --mpi=pmix")
+
+        assert rc == 0
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:4] == ["srun", "--mpi=pmix", "-n", "2"]
+
+
+class TestDivideGpusMps:
+    def test_warns_no_mps(self, mocker, caplog):
+        """Should warn when multiple ranks share a GPU but MPS is not running."""
+        mock_comm_ctx = mocker.MagicMock()
+        mock_comm = mock_comm_ctx.__enter__.return_value
+        mock_comm.size = 4
+        mock_comm.rank = 0
+
+        mocker.patch(
+            "femto.md.utils.mpi.get_mpi_comm",
+            autospec=True,
+            return_value=mock_comm_ctx,
+        )
+        mocker.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"})
+        mocker.patch("femto.md.utils.mpi.is_mps_running", return_value=False)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="femto.md.utils.mpi"):
+            femto.md.utils.mpi.divide_gpus()
+
+        assert os.environ["CUDA_VISIBLE_DEVICES"] == "0"
+        assert any("CUDA MPS does not appear to be running" in msg for msg in caplog.messages)
+

--- a/femto/md/utils/mpi.py
+++ b/femto/md/utils/mpi.py
@@ -187,18 +187,20 @@ def is_inside_mpi() -> bool:
 
 
 def is_mps_running() -> bool:
-    """Check if the CUDA MPS daemon is currently running."""
+    """Check if the CUDA MPS daemon is currently running.
+
+    Uses a ps-based process check instead of the interactive control
+    pipe, which can hang on newer NVIDIA drivers (580+).
+    """
 
     if not shutil.which("nvidia-cuda-mps-control"):
         return False
 
     try:
         result = subprocess.run(
-            ["nvidia-cuda-mps-control"],
-            input="get_default_active_thread_percentage\n",
+            ["pgrep", "-f", "nvidia-cuda-mps-server"],
             capture_output=True,
-            text=True,
-            timeout=5,
+            timeout=3,
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
@@ -224,6 +226,9 @@ def start_mps() -> None:
 
     _LOGGER.info("Starting CUDA MPS daemon")
     subprocess.run(["nvidia-cuda-mps-control", "-d"], check=True)
+    # Allow the daemon a moment to become ready before MPI ranks attach
+    import time
+    time.sleep(2)
 
 
 def stop_mps() -> None:

--- a/femto/md/utils/mpi.py
+++ b/femto/md/utils/mpi.py
@@ -271,11 +271,11 @@ def _strip_oversubscribe_from_argv(argv: list[str]) -> list[str]:
             skip_next = False
             continue
 
-        if arg == "--oversubscribe":
+        if arg in ("--oversubscribe", "-o"):
             skip_next = True
             continue
 
-        if arg.startswith("--oversubscribe="):
+        if arg.startswith("--oversubscribe=") or arg.startswith("-o="):
             continue
 
         result.append(arg)
@@ -317,6 +317,9 @@ def launch_with_mps(
     thread_pct = max(1, 200 // oversubscribe)
 
     child_argv = _strip_oversubscribe_from_argv(sys.argv)
+    
+    if child_argv and child_argv[0].endswith(".py"):
+        child_argv = [sys.executable, *child_argv]
 
     if mpi_command is not None:
         mpi_cmd = shlex.split(mpi_command) + ["-n", str(n_ranks)]

--- a/femto/md/utils/mpi.py
+++ b/femto/md/utils/mpi.py
@@ -1,11 +1,15 @@
-"""Utilities for interacting with MPI."""
+"""Utilities for interacting with MPI and CUDA MPS."""
 
 import contextlib
 import functools
 import logging
 import os
+import shlex
+import shutil
 import signal
 import socket
+import subprocess
+import sys
 import typing
 
 import GPUtil
@@ -163,6 +167,183 @@ def divide_tasks(mpi_comm: "MPI.Intracomm", n_tasks: int) -> tuple[int, int]:
     return n_replicas, replica_idx_offset
 
 
+def _count_cuda_devices() -> int:
+    """Count the number of available CUDA devices."""
+
+    if "CUDA_VISIBLE_DEVICES" in os.environ:
+        return len(os.environ["CUDA_VISIBLE_DEVICES"].split(","))
+
+    try:
+        return len(GPUtil.getGPUs())
+    except Exception:
+        return 0
+
+
+def is_inside_mpi() -> bool:
+    """Check if the current process was launched under an MPI runtime."""
+
+    mpi_env_vars = {"PMI_RANK", "PMIX_RANK", "OMPI_COMM_WORLD_SIZE"}
+    return any(v in os.environ for v in mpi_env_vars)
+
+
+def is_mps_running() -> bool:
+    """Check if the CUDA MPS daemon is currently running."""
+
+    if not shutil.which("nvidia-cuda-mps-control"):
+        return False
+
+    try:
+        result = subprocess.run(
+            ["nvidia-cuda-mps-control"],
+            input="get_default_active_thread_percentage\n",
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+
+def start_mps() -> None:
+    """Start the CUDA MPS daemon.
+
+    Raises:
+        RuntimeError: If ``nvidia-cuda-mps-control`` is not found or fails to start.
+    """
+
+    if not shutil.which("nvidia-cuda-mps-control"):
+        raise RuntimeError(
+            "nvidia-cuda-mps-control not found. Ensure the NVIDIA CUDA toolkit "
+            "is installed and on your PATH."
+        )
+
+    if is_mps_running():
+        _LOGGER.info("CUDA MPS daemon is already running")
+        return
+
+    _LOGGER.info("Starting CUDA MPS daemon")
+    subprocess.run(["nvidia-cuda-mps-control", "-d"], check=True)
+
+
+def stop_mps() -> None:
+    """Stop the CUDA MPS daemon."""
+
+    _LOGGER.info("Stopping CUDA MPS daemon")
+
+    subprocess.run(
+        ["nvidia-cuda-mps-control"],
+        input="quit\n",
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+
+@contextlib.contextmanager
+def mps_context():
+    """Context manager that starts the MPS daemon on entry and stops it on exit.
+
+    If MPS is already running when the context is entered, it will not be stopped
+    on exit.
+    """
+
+    already_running = is_mps_running()
+
+    if not already_running:
+        start_mps()
+
+    try:
+        yield
+    finally:
+        if not already_running:
+            stop_mps()
+
+
+def _strip_oversubscribe_from_argv(argv: list[str]) -> list[str]:
+    """Remove ``--oversubscribe`` and its value from an argv list."""
+
+    result = []
+    skip_next = False
+
+    for arg in argv:
+        if skip_next:
+            skip_next = False
+            continue
+
+        if arg == "--oversubscribe":
+            skip_next = True
+            continue
+
+        if arg.startswith("--oversubscribe="):
+            continue
+
+        result.append(arg)
+
+    return result
+
+
+def launch_with_mps(
+    oversubscribe: int,
+    mpi_command: str | None = None,
+) -> int:
+    """Re-launch the current command under MPI with CUDA MPS enabled.
+
+    This function detects the available GPUs, starts the MPS daemon, sets
+    ``CUDA_MPS_ACTIVE_THREAD_PERCENTAGE``, and re-execs the current command
+    under ``mpirun`` with ``n_gpus * oversubscribe`` ranks.
+
+    Args:
+        oversubscribe: The number of MPI ranks to place on each GPU.
+        mpi_command: The MPI launcher command (e.g. ``"mpirun"`` or
+            ``"srun --mpi=pmix"``). If ``None``, ``mpirun`` or ``mpiexec``
+            will be auto-detected.
+
+    Returns:
+        The return code of the MPI process.
+
+    Raises:
+        RuntimeError: If no CUDA devices or MPI launcher can be found.
+    """
+
+    n_gpus = _count_cuda_devices()
+
+    if n_gpus == 0:
+        raise RuntimeError(
+            "No CUDA devices found. Cannot launch with MPS oversubscription."
+        )
+
+    n_ranks = n_gpus * oversubscribe
+    thread_pct = max(1, 200 // oversubscribe)
+
+    child_argv = _strip_oversubscribe_from_argv(sys.argv)
+
+    if mpi_command is not None:
+        mpi_cmd = shlex.split(mpi_command) + ["-n", str(n_ranks)]
+    else:
+        mpirun = shutil.which("mpirun") or shutil.which("mpiexec")
+
+        if mpirun is None:
+            raise RuntimeError(
+                "Cannot find mpirun or mpiexec on PATH. Please install an MPI "
+                "implementation (e.g. Open MPI) or specify --mpi-command."
+            )
+
+        mpi_cmd = [mpirun, "-n", str(n_ranks), "--oversubscribe"]
+
+    env = {**os.environ, "CUDA_MPS_ACTIVE_THREAD_PERCENTAGE": str(thread_pct)}
+
+    _LOGGER.info(
+        f"Launching with CUDA MPS: {n_gpus} GPUs × {oversubscribe} ranks/GPU = "
+        f"{n_ranks} total ranks, CUDA_MPS_ACTIVE_THREAD_PERCENTAGE={thread_pct}%"
+    )
+
+    with mps_context():
+        result = subprocess.run([*mpi_cmd, *child_argv], env=env)
+
+    return result.returncode
+
+
 def divide_gpus():
     """Attempts to divide the available GPUs across MPI ranks. If there are more ranks
     than GPUs, then each GPU will be assigned to multiple ranks.
@@ -172,19 +353,27 @@ def divide_gpus():
     hostname = socket.gethostname()
 
     with get_mpi_comm() as mpi_comm:
-        n_cuda_devices = len(GPUtil.getGPUs())
-
-        if "CUDA_VISIBLE_DEVICES" in os.environ:
-            n_cuda_devices = len(os.environ["CUDA_VISIBLE_DEVICES"].split(","))
+        n_cuda_devices = _count_cuda_devices()
 
         if n_cuda_devices > 0:
             device_idx = mpi_comm.rank % n_cuda_devices
+            ranks_per_gpu = max(1, mpi_comm.size // n_cuda_devices)
+
             os.environ["CUDA_VISIBLE_DEVICES"] = f"{device_idx}"
 
             _LOGGER.debug(
                 f"hostname={hostname} "
-                f"rank={mpi4py.MPI.COMM_WORLD.rank} will use GPU={device_idx}"
+                f"rank={mpi4py.MPI.COMM_WORLD.rank} will use GPU={device_idx} "
+                f"({ranks_per_gpu} ranks/GPU)"
             )
+
+            if ranks_per_gpu > 1 and not is_mps_running():
+                _LOGGER.warning(
+                    f"Multiple MPI ranks ({ranks_per_gpu}) are sharing each GPU "
+                    f"but CUDA MPS does not appear to be running. Performance "
+                    f"will be degraded due to context switching. Start MPS with: "
+                    f"nvidia-cuda-mps-control -d"
+                )
 
         else:
             _LOGGER.debug(f"hostname={hostname} has no GPUs")


### PR DESCRIPTION
Following up on this [suggestion](https://github.com/Psivant/femto/issues/35#issue-3119501971)

## Overview
This pull request introduces support for NVIDIA Multi-Process Service (MPS) to improve replica-exchange MD (REMD) throughput by allowing multiple MPI ranks to concurrently share a single GPU.
## Key Changes
* **MPS Daemon Lifecycle Management**: Added `start_mps`, `stop_mps`, and `mps_context` utilities in `femto.md.utils.mpi` to safely spin up and tear down the NVIDIA MPS daemon (`nvidia-cuda-mps-control`) automatically.
* **Non-Blocking MPS Status Check**: Updated `is_mps_running()` to use `pgrep` instead of the interactive control pipe. The interactive pipe was prone to hanging on newer NVIDIA drivers (580+), which previously caused silent failures.
* **Auto-Relaunch via `--oversubscribe N`**: Implemented `launch_with_mps` to detect available hardware and automatically re-exec the application under an MPI launcher (e.g. `mpirun`) with `n_gpus * oversubscribe` ranks.
* **Dynamic GPU Distribution**: Updated `divide_gpus` to intelligently stripe MPI ranks across available CUDA devices using modulo arithmetic, exporting the correct `CUDA_VISIBLE_DEVICES` per rank. 
* **Thread Throttling**: Automatically sets `CUDA_MPS_ACTIVE_THREAD_PERCENTAGE` based on the oversubscription factor to prevent context-switching thrashing and guarantee fair resource allocation among concurrent replicas.
## Testing & Verification
* Verified MPS daemon successfully starts on nodes with CUDA devices and correctly exits or persists based on pre-existing state.
* Monitored GPU utilization, demonstrating significant increase in aggregate simulation throughput when running 2 or more replicas per GPU compared to serial execution.
* Confirmed that `pgrep` safely avoids the driver 580+ hanging issue.
